### PR TITLE
Timeline indexページはフォローしたユーザーのPostだけを表示させるようにした

### DIFF
--- a/sns_laravel_project/app/Http/Controllers/PostsController.php
+++ b/sns_laravel_project/app/Http/Controllers/PostsController.php
@@ -10,7 +10,11 @@ use App\Http\Requests\PostRequest;
 class PostsController extends Controller
 {
     public function index() {
-        $posts = Post::latest()->get();
+        if (Auth::check()) {
+            $posts = Post::where('user_id', 3)->latest()->get();
+        } else {
+            $posts = Post::latest()->get();
+        }
         return view('posts.index')->with('posts', $posts);
     }
 

--- a/sns_laravel_project/app/Http/Controllers/PostsController.php
+++ b/sns_laravel_project/app/Http/Controllers/PostsController.php
@@ -5,13 +5,18 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\post;
+use App\Relationship;
 use App\Http\Requests\PostRequest;
 
 class PostsController extends Controller
 {
     public function index() {
         if (Auth::check()) {
-            $posts = Post::where('user_id', 3)->latest()->get();
+            $relationship = Relationship::where('user_id', Auth::id())->get()->toArray();
+            // dd($relationship);
+            // $follow = [1, 2, 3];
+            $follow = array_column($relationship, 'followed_user_id');
+            $posts = Post::whereIn('user_id', $follow)->latest()->get();
         } else {
             $posts = Post::latest()->get();
         }

--- a/sns_laravel_project/app/Http/Controllers/PostsController.php
+++ b/sns_laravel_project/app/Http/Controllers/PostsController.php
@@ -12,11 +12,11 @@ class PostsController extends Controller
 {
     public function index() {
         if (Auth::check()) {
+            // フォローしているユーザーを取得
             $relationship = Relationship::where('user_id', Auth::id())->get()->toArray();
-            // dd($relationship);
-            // $follow = [1, 2, 3];
+            // フォローしているユーザーのIDを配列で取得
             $follow = array_column($relationship, 'followed_user_id');
-            $posts = Post::whereIn('user_id', $follow)->latest()->get();
+            $posts = Post::whereIn('user_id', $follow)->orWhere('user_id', Auth::id())->latest()->get();
         } else {
             $posts = Post::latest()->get();
         }


### PR DESCRIPTION
```
$follow = array_column($relationship, 'followed_user_id');
$posts = Post::whereIn('user_id', $follow)->orWhere('user_id', Auth::id())->latest()->get();
```

今回新しく覚えたこと + 実装のキモとなったコード
- array_column
- whereIn

arrau_coloumn  はカラムを配列で取得する際に使用した。
whereIn は  データベースから or 検索する際にwhere の条件を複数指定できる
第二引数に配列を格納した変数を入れることもできる