### PR TITLE
ログイン後でも新着postが確認できるページを追加

### DIFF
--- a/sns_laravel_project/app/Http/Controllers/PostsController.php
+++ b/sns_laravel_project/app/Http/Controllers/PostsController.php
@@ -23,6 +23,11 @@ class PostsController extends Controller
         return view('posts.index')->with('posts', $posts);
     }
 
+    public function newInfo() {
+        $posts = Post::latest()->get();
+        return view('posts.index')->with('posts', $posts);
+    }
+
     public function create() {
         return view('posts.create');
     }

--- a/sns_laravel_project/resources/views/layouts/app.blade.php
+++ b/sns_laravel_project/resources/views/layouts/app.blade.php
@@ -44,11 +44,15 @@
                                 </li>
                             @endif
                         @else
+                            <li class="nav-item">
+                                <a class="nav-link" href="{{ url('/posts/new-info') }}">
+                                    {{ __('新着') }}
+                                </a>
+                            </li>
                             <li class="nav-item dropdown">
                                 <a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
                                     {{ Auth::user()->name }} <span class="caret"></span>
                                 </a>
-
                                 <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
                                     <a class="dropdown-item" href="{{ url('/users', Auth::id()) }}">
                                         {{ __('マイページ') }}

--- a/sns_laravel_project/routes/web.php
+++ b/sns_laravel_project/routes/web.php
@@ -16,6 +16,7 @@ Route::get('/users/1/edit', 'PostsController@testuser');
 
 // posts
 Route::get('/', 'PostsController@index');
+Route::get('/posts/new-info', 'PostsController@newInfo');
 Route::get('/post/{post}/edit', 'PostsController@edit');
 Route::patch('/', 'PostsController@update');
 


### PR DESCRIPTION

PostsControllerにnewInfoアクションを追加して
ログイン後のheaderにposts/new-infoを追加。
posts/new-infoへgetリクエストが来たら、PostsControllerのnewInfoアクションが反応するようにルーティングを設定した。